### PR TITLE
Fix Navbar & Side Drawer bugs

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -12,7 +12,7 @@ interface Props {
 const { title, content, to, image = "" } = Astro.props;
 ---
 
-<div class="card w-96 lg:w-full lg:card-side bg-base-100 shadow-xl">
+<div class="card w-full lg:card-side bg-base-100 shadow-xl">
 	{
 		image && (
 			<figure>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,7 @@ import NavContent from "./NavContent.astro";
 ---
 
 <!-- Navbar -->
-<div class="sticky lg:static bg-base-100 top-0 navbar z-40">
+<div class="sticky navbar lg:static bg-base-100 top-0 z-40">
 	<div class="navbar-start lg:hidden">
 		<label for="my-drawer" class="btn btn-square btn-ghost">
 			<svg

--- a/src/components/SideDrawer.astro
+++ b/src/components/SideDrawer.astro
@@ -4,9 +4,9 @@ import NavContent from "./NavContent.astro";
 import ProfileImage from "../assets/images/profile.jpg";
 ---
 
-<div class="drawer-side z-50">
+<div class="drawer-side z-50 lg:hidden">
 	<label for="my-drawer" class="drawer-overlay"></label>
-	<ul class="menu p-4 w-72 min-h-full bg-base-200">
+	<ul class="menu p-4 w-80 min-h-full bg-base-200">
 		<!-- Sidebar content here -->
 		<li>
 			<div class="avatar mx-auto my-4">

--- a/src/pages/projects/[...page].astro
+++ b/src/pages/projects/[...page].astro
@@ -17,7 +17,7 @@ const { page } = Astro.props;
 	<section class="pt-6">
 		<div class="space-y-6">
 			{
-				page.data.map((p) => (
+				page.data.map((p: any) => (
 					<Card title={p.data.title} to={`/projects/${p.slug}`} content={p.data.body} image={p.data.image} />
 				))
 			}


### PR DESCRIPTION
Side drawer would flicker open then close when navigating around the site.

The navbar was a different size/scale on the /projects page. This was due to the "w-96" on the card component.